### PR TITLE
Fix music toggle rerender loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,6 @@ import birthdayMusic from "./audio/musicOOG.ogg";
 
 function App() {
   const [isPlaying, setIsPlaying] = useState(false);
-  setIsPlaying(false);
   const [isLoading, setIsLoading] = useState(true);
   const [play, { stop }] = useSound(birthdayMusic, {
     volume: 1,
@@ -32,6 +31,11 @@ function App() {
   const [poemRef, poemInView] = useInView({ triggerOnce: true });
 
   useSparkles();
+
+  // Ensure music starts in a stopped state on mount
+  useEffect(() => {
+    setIsPlaying(false);
+  }, []);
 
   useEffect(() => {
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- remove `setIsPlaying(false)` call from the render path in `App`
- ensure the audio state is reset only once on mount

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68412f2ccd608330aac946049bad878e